### PR TITLE
chore: Enable uploading attestations to PyPI

### DIFF
--- a/.github/workflows/dynamic-publish.yaml
+++ b/.github/workflows/dynamic-publish.yaml
@@ -35,3 +35,5 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.10.0
+        with:
+          attestations: true


### PR DESCRIPTION
Enable experimental support for PEP 740 attestations.
